### PR TITLE
#23 Story 테스트 코드 작성

### DIFF
--- a/Owing-Api/src/main/java/com/owing/api/dnd/controller/DndFileController.java
+++ b/Owing-Api/src/main/java/com/owing/api/dnd/controller/DndFileController.java
@@ -14,6 +14,7 @@ import com.owing.api.dnd.dto.common.request.CommonUpdateFilePositionRequest;
 import com.owing.api.dnd.service.DndFileCrudService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 
 public abstract class DndFileController {
 	protected abstract DndFileCrudService dndCrudService();
@@ -26,13 +27,13 @@ public abstract class DndFileController {
 
 	@PostMapping("/dnd")
 	@Operation(summary = "✨ DnD: 파일 or 폴더 생성", description = "폴더탭에서 파일이나 폴더를 생성합니다. DnD 생성은 Title만 받습니다.")
-	public ResponseEntity<?> createDnd(@RequestBody CommonAddFileRequest addDndRequest) {
+	public ResponseEntity<?> createDnd(@Valid @RequestBody CommonAddFileRequest addDndRequest) {
 		return ResponseEntity.ok(dndCrudService().create(addDndRequest));
 	}
 
 	@PatchMapping("/{id}/title")
 	@Operation(summary = "✨ DnD: 파일 or 폴더 이름 수정", description = "폴더탭에서 파일이나 폴더의 이름을 변경합니다.")
-	public ResponseEntity<Void> updateDndName(@PathVariable Long id, @RequestBody CommonUpdateFileNameRequest updateDndRequest) {
+	public ResponseEntity<Void> updateDndName(@PathVariable Long id, @Valid @RequestBody CommonUpdateFileNameRequest updateDndRequest) {
 		dndCrudService().updateName(id, updateDndRequest);
 		return ResponseEntity.noContent().build();
 	}

--- a/Owing-Api/src/main/java/com/owing/api/dnd/controller/DndFolderController.java
+++ b/Owing-Api/src/main/java/com/owing/api/dnd/controller/DndFolderController.java
@@ -16,6 +16,7 @@ import com.owing.api.dnd.service.DndFolderCrudService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 
 public abstract class DndFolderController {
 
@@ -29,13 +30,13 @@ public abstract class DndFolderController {
 
 	@PostMapping("/dnd")
 	@Operation(summary = "✨ DnD: 파일 or 폴더 생성", description = "폴더탭에서 파일이나 폴더를 생성합니다. DnD 생성은 Title만 받습니다.")
-	public ResponseEntity<?> createDnd(@RequestBody CommonAddFolderRequest addDndRequest) {
+	public ResponseEntity<?> createDnd(@RequestBody @Valid CommonAddFolderRequest addDndRequest) {
 		return ResponseEntity.ok(dndCrudService().create(addDndRequest));
 	}
 
 	@PatchMapping("/{id}/title")
 	@Operation(summary = "✨ DnD: 파일 or 폴더 이름 수정", description = "폴더탭에서 파일이나 폴더의 이름을 변경합니다.")
-	public ResponseEntity<Void> updateDndName(@PathVariable Long id, @RequestBody CommonUpdateFolderNameRequest updateDndRequest) {
+	public ResponseEntity<Void> updateDndName(@PathVariable Long id, @RequestBody @Valid CommonUpdateFolderNameRequest updateDndRequest) {
 		dndCrudService().updateName(id, updateDndRequest);
 		return ResponseEntity.noContent().build();
 	}

--- a/Owing-Api/src/main/java/com/owing/api/dnd/dto/common/request/CommonAddFileRequest.java
+++ b/Owing-Api/src/main/java/com/owing/api/dnd/dto/common/request/CommonAddFileRequest.java
@@ -2,9 +2,16 @@ package com.owing.api.dnd.dto.common.request;
 
 import com.owing.api.dnd.dto.request.AddFileRequest;
 
-public record CommonAddFileRequest(
-		String name,
-		Long folderId
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
-)implements AddFileRequest {
+public record CommonAddFileRequest(
+	@NotNull(message = "파일명은 필수입니다.")
+	@Size(min = 1, max = 50, message = "파일명은 1자 이상 50자 이하로 입력해야 합니다.")
+	String name,
+
+	@NotNull(message = "폴더 ID는 필수입니다.")
+	Long folderId
+
+) implements AddFileRequest {
 }

--- a/Owing-Api/src/main/java/com/owing/api/dnd/dto/common/request/CommonAddFolderRequest.java
+++ b/Owing-Api/src/main/java/com/owing/api/dnd/dto/common/request/CommonAddFolderRequest.java
@@ -2,8 +2,15 @@ package com.owing.api.dnd.dto.common.request;
 
 import com.owing.api.dnd.dto.request.AddFolderRequest;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 public record CommonAddFolderRequest(
+	@NotNull(message = "파일명은 필수입니다.")
+	@Size(min = 1, max = 50, message = "파일명은 1자 이상 50자 이하로 입력해야 합니다.")
 	String name,
+
+	@NotNull(message = "프로젝트 ID는 필수입니다.")
 	Long projectId
 ) implements AddFolderRequest {
 }

--- a/Owing-Api/src/main/java/com/owing/api/dnd/dto/common/request/CommonUpdateFileNameRequest.java
+++ b/Owing-Api/src/main/java/com/owing/api/dnd/dto/common/request/CommonUpdateFileNameRequest.java
@@ -2,7 +2,12 @@ package com.owing.api.dnd.dto.common.request;
 
 import com.owing.api.dnd.dto.request.UpdateFileNameRequest;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 public record CommonUpdateFileNameRequest(
+	@NotNull(message = "파일명은 필수입니다.")
+	@Size(min = 1, max = 50, message = "파일명은 1자 이상 50자 이하로 입력해야 합니다.")
 	String name
 ) implements UpdateFileNameRequest {
 }

--- a/Owing-Api/src/main/java/com/owing/api/dnd/dto/common/request/CommonUpdateFolderNameRequest.java
+++ b/Owing-Api/src/main/java/com/owing/api/dnd/dto/common/request/CommonUpdateFolderNameRequest.java
@@ -2,7 +2,12 @@ package com.owing.api.dnd.dto.common.request;
 
 import com.owing.api.dnd.dto.request.UpdateFolderNameRequest;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 public record CommonUpdateFolderNameRequest(
+	@NotNull(message = "파일명은 필수입니다.")
+	@Size(min = 1, max = 50, message = "파일명은 1자 이상 50자 이하로 입력해야 합니다.")
 	String name
 ) implements UpdateFolderNameRequest {
 }

--- a/Owing-Api/src/main/java/com/owing/api/story/controller/StoryController.java
+++ b/Owing-Api/src/main/java/com/owing/api/story/controller/StoryController.java
@@ -29,6 +29,7 @@ import com.owing.api.story.service.dnd.StoryCrudService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -53,7 +54,7 @@ public class StoryController extends DndFileController {
 
 	@PutMapping("/{storyId}")
 	@Operation(summary = "✨일반: 원고 정보 수정", description = "원고 정보를 수정합니다.")
-	public ResponseEntity<?> updateStory(@PathVariable Long storyId, @RequestBody UpdateStoryRequest request) {
+	public ResponseEntity<?> updateStory(@PathVariable Long storyId, @RequestBody @Valid UpdateStoryRequest request) {
 		updateStoryUseCase.execute(storyId, request);
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}

--- a/Owing-Api/src/main/java/com/owing/api/story/model/dto/request/UpdateStoryRequest.java
+++ b/Owing-Api/src/main/java/com/owing/api/story/model/dto/request/UpdateStoryRequest.java
@@ -1,6 +1,11 @@
 package com.owing.api.story.model.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 public record UpdateStoryRequest(
+	@NotNull(message = "파일명은 필수입니다.")
+	@Size(min = 1, max = 50, message = "파일명은 1자 이상 50자 이하로 입력해야 합니다.")
 	String name,
 	String description
 ) {

--- a/Owing-Api/src/test/java/com/owing/api/story/controller/StoryAIControllerTest.java
+++ b/Owing-Api/src/test/java/com/owing/api/story/controller/StoryAIControllerTest.java
@@ -1,0 +1,180 @@
+package com.owing.api.story.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.owing.api.story.model.dto.response.CrashCheckItemResponse;
+import com.owing.api.story.model.dto.response.CrashCheckLogResponse;
+import com.owing.api.story.model.dto.response.StorySpellCheckLogResponse;
+import com.owing.api.story.model.dto.response.StorySpellCheckResponse;
+import com.owing.api.utils.TestAuthUtils;
+import com.owing.api.utils.TestEnvLoader;
+import com.owing.entity.domains.ai.log.story.model.CrashCheckLog;
+import com.owing.entity.domains.ai.log.story.model.CrashCheckOutput;
+import com.owing.entity.domains.ai.log.story.model.SpellCheckLog;
+import com.owing.entity.domains.ai.log.story.model.SpellCheckOutput;
+import com.owing.entity.domains.ai.log.story.repository.CrashCheckLogRepository;
+import com.owing.entity.domains.ai.log.story.repository.SpellCheckLogRepository;
+import com.owing.entity.domains.member.model.Member;
+import com.owing.entity.domains.project.model.Project;
+import com.owing.entity.domains.story.model.Story;
+import com.owing.entity.domains.story.model.StoryFolder;
+
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional("jpaTransactionManager")
+@SpringBootTest
+class StoryAIControllerTest {
+
+	private static final String BASE_URL = "/v1/stories";
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private TestAuthUtils testAuthUtils;
+
+	@Autowired
+	private StoryTest storyTest;
+	@Autowired
+	private CrashCheckLogRepository crashCheckLogRepository;
+	@Autowired
+	private SpellCheckLogRepository spellCheckLogRepository;
+
+	private Member member;
+	private Project project;
+	private Story story;
+	private StoryFolder folder;
+
+
+	@DynamicPropertySource
+	static void registerProps(DynamicPropertyRegistry registry) {
+		TestEnvLoader.load(registry);
+	}
+
+	@BeforeEach
+	void setUp() {
+		member = testAuthUtils.createMember("test");
+		project = testAuthUtils.createProject(member);
+		folder = storyTest.createStoryFolder(project.getId());
+		story = storyTest.createStory(folder);
+	}
+
+	@Test
+	@DisplayName("✨ AI: 설정 충돌 로그 조회 - 성공")
+	void getCrashCheckLog_success() throws Exception {
+		// given
+		List<CrashCheckOutput> output = List.of(
+			new CrashCheckOutput("base1", "add1", "reason1"),
+			new CrashCheckOutput("base2", "add2", "reason2")
+		);
+		CrashCheckLog log = crashCheckLogRepository.save(new CrashCheckLog(story, output));
+
+		List<CrashCheckItemResponse> items = output.stream()
+			.map(o -> new CrashCheckItemResponse(o.base(), o.add(), o.reason()))
+			.toList();
+
+		CrashCheckLogResponse expected = new CrashCheckLogResponse(
+			log.getId(),
+			items,
+			log.getCreatedAt()
+		);
+
+		// when
+		MvcResult result = mockMvc.perform(get(BASE_URL + "/{storyId}/crash-check", story.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+			)
+			.andExpect(status().isOk())
+			.andReturn();
+
+		// then
+		String content = result.getResponse().getContentAsString();
+		List<CrashCheckLogResponse> actual = objectMapper.readValue(content, new TypeReference<>() {});
+
+		assertThat(actual).hasSize(1);
+		assertThat(actual.getFirst())
+			.usingRecursiveComparison()
+			.isEqualTo(expected);
+	}
+
+
+	@Test
+	@DisplayName("❗ AI: 설정 충돌 로그 조회 - 존재하지 않는 원고 ID")
+	void getCrashCheckLog_notFound() throws Exception {
+		// when // then
+		mockMvc.perform(get(BASE_URL + "/{storyId}/crash-check", 99999L)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	@DisplayName("✨ AI: 맞춤법 로그 조회 - 성공")
+	void getSpellCheckLog_success() throws Exception {
+		// given
+		List<SpellCheckOutput> output = List.of(
+			new SpellCheckOutput("help1", 1, 0, 0, "errMsg1", 2, "orgStr1", "candWord1"),
+			new SpellCheckOutput("help2", 3, 1, 3, "errMsg2", 5, "orgStr2", "candWord2")
+		);
+		SpellCheckLog log = spellCheckLogRepository.save(new SpellCheckLog(story, output));
+
+		List<StorySpellCheckResponse> items = output.stream()
+			.map(o -> new StorySpellCheckResponse(
+				o.help(), o.errorIdx(), o.correctMethod(), o.start(), o.errMsg(), o.end(), o.orgStr(), o.candWord()
+			))
+			.toList();
+
+		StorySpellCheckLogResponse expected = new StorySpellCheckLogResponse(
+			log.getId(),
+			items,
+			log.getCreatedAt()
+		);
+
+		// when
+		MvcResult result = mockMvc.perform(get(BASE_URL + "/{storyId}/spell-check", story.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		String content = result.getResponse().getContentAsString();
+		List<StorySpellCheckLogResponse> actual = objectMapper.readValue(content, new TypeReference<>() {
+		});
+
+		// then
+		assertThat(actual).hasSize(1);
+		assertThat(actual.getFirst())
+			.usingRecursiveComparison()
+			.isEqualTo(expected);
+	}
+
+	@Test
+	@DisplayName("❗ AI: 맞춤법 로그 조회 - 존재하지 않는 원고 ID")
+	void getSpellCheckLog_notFound() throws Exception {
+		// when // then
+		mockMvc.perform(get(BASE_URL + "/{storyId}/spell-check", 99999L)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isNotFound());
+	}
+
+}

--- a/Owing-Api/src/test/java/com/owing/api/story/controller/StoryControllerTest.java
+++ b/Owing-Api/src/test/java/com/owing/api/story/controller/StoryControllerTest.java
@@ -1,0 +1,179 @@
+package com.owing.api.story.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.owing.api.story.model.dto.request.AddStoryContentRequest;
+import com.owing.api.story.model.dto.request.UpdateStoryRequest;
+import com.owing.api.utils.TestAuthUtils;
+import com.owing.api.utils.TestEnvLoader;
+import com.owing.entity.domains.member.model.Member;
+import com.owing.entity.domains.project.model.Project;
+import com.owing.entity.domains.story.model.Story;
+import com.owing.entity.domains.story.model.StoryFolder;
+import com.owing.entity.domains.story.repository.StoryRepository;
+
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional("jpaTransactionManager")
+@SpringBootTest
+class StoryControllerTest {
+	private static final String BASE_URL = "/v1/stories";
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private TestAuthUtils testAuthUtils;
+	@Autowired
+	private StoryTest storyTest;
+
+	private Member member;
+	private Project project;
+	private StoryFolder folder;
+	private Long storyId;
+	@Autowired
+	private StoryRepository storyRepository;
+
+	@DynamicPropertySource
+	static void registerProps(DynamicPropertyRegistry registry) {
+		TestEnvLoader.load(registry);
+	}
+
+	@BeforeEach
+	void setUp() {
+		member = testAuthUtils.createMember("test");
+		project = testAuthUtils.createProject(member);
+		folder = storyTest.createStoryFolder(project.getId());
+		storyId = storyTest.createStory(folder).getId();
+	}
+
+	@Test
+	@DisplayName("✨ 원고 내용 작성 - 성공")
+	void createStory_success() throws Exception {
+		// given
+		String content = """
+			<div style="color: yellow;">test1</div>
+			<div style="color: yellow;">test2</div>
+		""";
+
+		AddStoryContentRequest request = new AddStoryContentRequest(content);
+
+		// when
+		mockMvc.perform(post(BASE_URL + "/{storyId}", storyId)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+			)
+			.andExpect(status().isOk());
+
+		// then
+		Optional<Story> story = storyRepository.findById(storyId);
+		assertThat(story).isPresent();
+		assertThat(story.get().getContent()).isEqualTo(content);
+		assertThat(story.get().getTextCount()).isEqualTo(11);
+	}
+
+	@Test
+	@DisplayName("❗ 원고 내용 작성 - 존재하지 않는 storyId")
+	void createStory_notFound() throws Exception {
+		// given
+		AddStoryContentRequest request = new AddStoryContentRequest(
+			"""
+					<div style="color: yellow;">test1</div>
+					<div style="color: yellow;">test2</div>
+				"""
+		);
+
+		// when // then
+		mockMvc.perform(post(BASE_URL + "/{storyId}", 99999L)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+			)
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	@DisplayName("✨ 원고 정보 수정 - 성공")
+	void updateStory_success() throws Exception {
+		// given
+		UpdateStoryRequest request = new UpdateStoryRequest(
+			"updatedName",
+			"updatedDescription"
+		);
+
+		// when // then
+		mockMvc.perform(put(BASE_URL + "/{storyId}", storyId)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+			)
+			.andExpect(status().isOk());
+	}
+
+	@ParameterizedTest
+	@DisplayName("❗ 원고 정보 수정 - 유효하지 않은 요청값")
+	@MethodSource("invalidStoryRequests")
+	void updateStory_invalidRequest(UpdateStoryRequest invalidRequest) throws Exception {
+		// when // then
+		mockMvc.perform(put(BASE_URL + "/{storyId}", storyId)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(invalidRequest))
+			)
+			.andExpect(status().isBadRequest());
+	}
+
+	private static Stream<UpdateStoryRequest> invalidStoryRequests() {
+		return Stream.of(
+			new UpdateStoryRequest(null, ""),
+			new UpdateStoryRequest("", null),
+			new UpdateStoryRequest("a".repeat(51), null)
+		);
+	}
+
+	@Test
+	@DisplayName("❗ 원고 정보 수정 - 존재하지 않는 storyId")
+	void updateStory_notFound() throws Exception {
+		// given
+		UpdateStoryRequest request = new UpdateStoryRequest(
+			"updatedName",
+			"updatedDescription"
+		);
+
+		// when // then
+		mockMvc.perform(put(BASE_URL + "/{storyId}", 99999L)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+			)
+			.andExpect(status().isNotFound());
+	}
+
+}

--- a/Owing-Api/src/test/java/com/owing/api/story/controller/StoryDnDControllerTest.java
+++ b/Owing-Api/src/test/java/com/owing/api/story/controller/StoryDnDControllerTest.java
@@ -1,0 +1,251 @@
+package com.owing.api.story.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.owing.api.dnd.dto.common.request.CommonAddFileRequest;
+import com.owing.api.dnd.dto.common.request.CommonUpdateFileNameRequest;
+import com.owing.api.dnd.dto.common.request.CommonUpdateFilePositionRequest;
+import com.owing.api.story.model.dto.response.StoryInfoResponse;
+import com.owing.api.utils.TestAuthUtils;
+import com.owing.api.utils.TestEnvLoader;
+import com.owing.entity.domains.member.model.Member;
+import com.owing.entity.domains.project.model.Project;
+import com.owing.entity.domains.story.model.Story;
+import com.owing.entity.domains.story.model.StoryFolder;
+import com.owing.entity.domains.trashcan.model.FolderType;
+import com.owing.entity.domains.trashcan.repository.TrashCanFolderRepository;
+import com.owing.entity.domains.trashcan.repository.TrashCanRepository;
+
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional("jpaTransactionManager")
+@SpringBootTest
+class StoryDnDControllerTest {
+	private static final String BASE_URL = "/v1/stories";
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private TestAuthUtils testAuthUtils;
+	@Autowired
+	private StoryTest storyTest;
+
+	private Member member;
+	private Project project;
+	private StoryFolder folder;
+	private Story story;
+	@Autowired
+	private TrashCanFolderRepository trashCanFolderRepository;
+	@Autowired
+	private TrashCanRepository trashCanRepository;
+
+	@DynamicPropertySource
+	static void registerProps(DynamicPropertyRegistry registry) {
+		TestEnvLoader.load(registry);
+	}
+
+	@BeforeEach
+	void setUp() {
+		member = testAuthUtils.createMember("test");
+		project = testAuthUtils.createProject(member);
+		folder = storyTest.createStoryFolder(project.getId());
+		story = storyTest.createStory(folder);
+	}
+
+	@Test
+	@DisplayName("✨ Story 생성 - 성공")
+	void createDnd_success() throws Exception {
+		// given
+		CommonAddFileRequest request = new CommonAddFileRequest(
+			"testFile1",
+			folder.getId()
+		);
+
+		// when
+		MvcResult result = mockMvc.perform(post(BASE_URL + "/dnd")
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+			)
+			.andExpect(status().isOk())
+			.andReturn();
+
+		// then
+		String content = result.getResponse().getContentAsString();
+		StoryInfoResponse response = objectMapper.readValue(content, StoryInfoResponse.class);
+
+		assertThat(response.storyId()).isGreaterThan(0L);
+		assertThat(response.name()).isEqualTo("testFile1");
+		assertThat(response.description()).isNullOrEmpty();
+		assertThat(response.textCount()).isEqualTo(0);
+		assertThat(response.content()).isEqualTo("");
+	}
+
+	@ParameterizedTest
+	@DisplayName("❗ Story 생성 - 유효하지 않은 요청값")
+	@MethodSource("invalidDndRequests")
+	void createDnd_invalidRequest(CommonAddFileRequest invalidRequest) throws Exception {
+		// when // then
+		mockMvc.perform(post(BASE_URL + "/dnd")
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(invalidRequest))
+			)
+			.andExpect(status().isBadRequest());
+	}
+
+	private static Stream<CommonAddFileRequest> invalidDndRequests() {
+		return Stream.of(
+			new CommonAddFileRequest(null, 1L),
+			new CommonAddFileRequest("", 1L),
+			new CommonAddFileRequest("a".repeat(51), 1L),
+			new CommonAddFileRequest("valid", null)
+		);
+	}
+
+	@Test
+	@DisplayName("✨ Story 상세 조회 - 성공")
+	void getDnd_success() throws Exception {
+		// when
+		MvcResult result = mockMvc.perform(get(BASE_URL + "/{id}", story.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		// then
+		String content = result.getResponse().getContentAsString();
+		StoryInfoResponse response = objectMapper.readValue(content, StoryInfoResponse.class);
+
+		assertThat(response.storyId()).isEqualTo(story.getId());
+		assertThat(response.name()).isEqualTo("testFile1");
+		assertThat(response.description()).isEqualTo("test");
+		assertThat(response.textCount()).isEqualTo(0);
+		assertThat(response.content()).isEqualTo("");
+	}
+
+	@Test
+	@DisplayName("❗ Story 상세 조회 - 존재하지 않는 Id")
+	void getDnd_notFound() throws Exception {
+		// when // then
+		mockMvc.perform(get(BASE_URL + "/{id}", 99999L)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	@DisplayName("✨ Story 이름 변경 - 성공")
+	void updateDndName_success() throws Exception {
+		// given
+		CommonUpdateFileNameRequest request = new CommonUpdateFileNameRequest("updatedName");
+
+		// when // then
+		mockMvc.perform(patch(BASE_URL + "/{id}/title", story.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNoContent());
+	}
+
+	@ParameterizedTest
+	@DisplayName("❗ Story 이름 변경 - 유효하지 않은 요청")
+	@MethodSource("invalidFileNameRequests")
+	void updateDndName_invalidRequest(CommonUpdateFileNameRequest invalidRequest) throws Exception {
+		// when // then
+		mockMvc.perform(patch(BASE_URL + "/{id}/title", story.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(invalidRequest)))
+			.andExpect(status().isBadRequest());
+	}
+
+	private static Stream<CommonUpdateFileNameRequest> invalidFileNameRequests() {
+		return Stream.of(
+			new CommonUpdateFileNameRequest(null),
+			new CommonUpdateFileNameRequest(""),
+			new CommonUpdateFileNameRequest(" ".repeat(1)),
+			new CommonUpdateFileNameRequest("a".repeat(51))
+		);
+	}
+
+	@Test
+	@DisplayName("❗Story 이름 변경 - 존재하지 않는 Id")
+	void updateDndName_notFound() throws Exception {
+		// given
+		CommonUpdateFileNameRequest request = new CommonUpdateFileNameRequest("updatedName");
+
+		// when // then
+		mockMvc.perform(patch(BASE_URL + "/{id}/title", 99999L)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	@DisplayName("✨ Story 위치 이동 - 성공")
+	void updateDndPosition_success() throws Exception {
+		// given
+		Long storyId1 = story.getId();
+		Long storyId2 = storyTest.createStory(folder, "testFile2", 1L).getId();
+		Long storyId3 = storyTest.createStory(folder, "testFile3",2L).getId();
+
+		CommonUpdateFilePositionRequest request = new CommonUpdateFilePositionRequest(storyId1, storyId2,
+			folder.getId());
+
+		// when // then
+		mockMvc.perform(patch(BASE_URL + "/{id}/position", storyId3)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNoContent());
+	}
+
+	@Test
+	@DisplayName("✨ Story 삭제 - 성공")
+	void deleteDnd_success() throws Exception {
+		// when // then
+		mockMvc.perform(delete(BASE_URL + "/{id}", story.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isNoContent());
+
+		// trashcan
+		assertThat(trashCanFolderRepository.findByItemIdAndTableName(folder.getId(), FolderType.STORY)).isPresent();
+		assertThat(trashCanRepository.findByItemId(story.getId())).isPresent();
+	}
+
+	@Test
+	@DisplayName("❗ Story 삭제 - 존재하지 않는 Id")
+	void deleteDnd_notFound() throws Exception {
+		// when // then
+		mockMvc.perform(delete(BASE_URL + "/{id}", 99999L)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isNotFound());
+	}
+
+}

--- a/Owing-Api/src/test/java/com/owing/api/story/controller/StoryDnDShiftTest.java
+++ b/Owing-Api/src/test/java/com/owing/api/story/controller/StoryDnDShiftTest.java
@@ -1,0 +1,354 @@
+package com.owing.api.story.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.owing.api.dnd.dto.common.request.CommonAddFileRequest;
+import com.owing.api.dnd.dto.common.request.CommonUpdateFilePositionRequest;
+import com.owing.api.story.model.dto.response.StoryInfoResponse;
+import com.owing.api.utils.TestAuthUtils;
+import com.owing.api.utils.TestEnvLoader;
+import com.owing.entity.domains.member.model.Member;
+import com.owing.entity.domains.project.model.Project;
+import com.owing.entity.domains.story.model.Story;
+import com.owing.entity.domains.story.model.StoryFolder;
+import com.owing.entity.domains.story.repository.StoryRepository;
+import com.owing.entity.domains.trashcan.repository.TrashCanRepository;
+
+import jakarta.persistence.EntityManager;
+
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional("jpaTransactionManager")
+@SpringBootTest
+class StoryDnDShiftTest {
+	private static final String BASE_URL = "/v1/stories";
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private TestAuthUtils testAuthUtils;
+	@Autowired
+	private StoryTest storyTest;
+	@Autowired
+	private StoryRepository storyRepository;
+
+	private Member member;
+	private Project project;
+	private StoryFolder f1;
+	private Story a;
+	private Story b;
+	private Story c;
+	private StoryFolder f2;
+	private Story d;
+	private Story e;
+	private Story f;
+	@Autowired
+	private EntityManager em;
+	@Autowired
+	private TrashCanRepository trashCanRepository;
+
+	@DynamicPropertySource
+	static void registerProps(DynamicPropertyRegistry registry) {
+		TestEnvLoader.load(registry);
+	}
+
+	@BeforeEach
+	void setUp() {
+		member = testAuthUtils.createMember("test");
+		project = testAuthUtils.createProject(member);
+		f1 = storyTest.createStoryFolder(project.getId());
+		a = storyTest.createStory(f1, "a", 0L);
+		b = storyTest.createStory(f1, "b", 1L);
+		c = storyTest.createStory(f1, "c", 2L);
+		f2 = storyTest.createStoryFolder(project.getId());
+		d = storyTest.createStory(f2, "d", 0L);
+		e = storyTest.createStory(f2, "e", 1L);
+		f = storyTest.createStory(f2, "f", 2L);
+	}
+
+	ResultActions updatePosition(Story story, Story before, Story after, StoryFolder folder) throws Exception {
+		CommonUpdateFilePositionRequest req = new CommonUpdateFilePositionRequest(
+			before == null ? null : before.getId(),
+			after == null ? null : after.getId(),
+			folder == null ? null : folder.getId()
+		);
+		return mockMvc.perform(patch(BASE_URL + "/{id}/position", story.getId())
+			.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(req)));
+	}
+
+	void assertPosition(StoryFolder folder, Story... expected) {
+		List<Story> stories = storyRepository.findByParentId(folder.getId());
+
+		assertThat(stories).hasSize(expected.length);
+
+		for (int i = 0; i < expected.length; i++) {
+			Story story = stories.get(i);
+			System.out.println(story.getName() + " : " + story.getPosition());
+			assertThat(story.getName()).isEqualTo(expected[i].getName());
+			assertThat(story.getPosition()).isEqualTo(i);
+		}
+	}
+
+	@Test
+	@DisplayName("✨ 동일 폴더 - before only -> before 다음에 위치")
+	void case1_beforeOnly_sameFolder() throws Exception {
+		// when
+		updatePosition(b, c, null, f1)
+			.andExpect(status().isNoContent());
+		em.flush();
+		em.clear();
+
+		// then
+		assertPosition(f1, a, c, b);
+	}
+
+	@Test
+	@DisplayName("✨ 동일 폴더 - after only -> after 이전에 위치")
+	void case2_afterOnly_sameFolder() throws Exception {
+		// when
+		updatePosition(c, null, b, f1)
+			.andExpect(status().isNoContent());
+		em.flush();
+		em.clear();
+
+		// then
+		assertPosition(f1, a, c, b);
+	}
+
+	@Test
+	@DisplayName("✨ 동일 폴더 - before, after -> between 위치")
+	void case3_beforeAfter_sameFolder() throws Exception {
+		// when
+		updatePosition(c, a, b, f1)
+			.andExpect(status().isNoContent());
+		em.flush();
+		em.clear();
+		// then
+		assertPosition(f1, a, c, b);
+	}
+
+	@Test
+	@DisplayName("✨ 동일 폴더 - f1 only -> 변경점 없음")
+	void case4_f1Only_sameFolderNotEmpty() throws Exception {
+		// when
+		updatePosition(a, null, null, f1)
+			.andExpect(status().isNoContent());
+		em.flush();
+		em.clear();
+		// then
+		assertPosition(f1, a, b, c);
+	}
+
+	@Test
+	@DisplayName("✨ 다른 폴더 - before only -> before 다음에 위치")
+	void case5_beforeOnly_diffFolder() throws Exception {
+		// when
+		updatePosition(b, e, null, f2)
+			.andExpect(status().isNoContent());
+		em.flush();
+		em.clear();
+		// then
+		assertPosition(f1, a, c);
+		assertPosition(f2, d, e, b, f);
+	}
+
+	@Test
+	@DisplayName("✨ 다른 폴더 - after only -> after 이전에 위치")
+	void case6_afterOnly_diffFolder() throws Exception {
+		// when
+		updatePosition(b, null, e, f2)
+			.andExpect(status().isNoContent());
+		em.flush();
+		em.clear();
+		// then
+		assertPosition(f1, a, c);
+		assertPosition(f2, d, b, e, f);
+	}
+
+	@Test
+	@DisplayName("✨ 다른 폴더 - before, after -> between 위치")
+	void case7_beforeAfter_diffFolder() throws Exception {
+		// when
+		updatePosition(b, e, f, f2)
+			.andExpect(status().isNoContent());
+		em.flush();
+		em.clear();
+		// then
+		assertPosition(f1, a, c);
+		assertPosition(f2, d, e, b, f);
+	}
+
+	@Test
+	@DisplayName("✨ 다른 폴더 - folder only -> 맨 마지막")
+	void case8_folderOnly_diffFolderNotEmpty() throws Exception {
+		// when
+		updatePosition(b, null, null, f2)
+			.andExpect(status().isNoContent());
+		em.flush();
+		em.clear();
+		// then
+		assertPosition(f1, a, c);
+		assertPosition(f2, d, e, f, b);
+	}
+
+	@Test
+	@DisplayName("✨ 다른 폴더 - folder only -> 0번 위치")
+	void case9_folderOnly_diffFolderEmpty() throws Exception {
+		// given
+		StoryFolder f3 = storyTest.createStoryFolder(project.getId());
+
+		// when
+		updatePosition(b, null, null, f3)
+			.andExpect(status().isNoContent());
+		em.flush();
+		em.clear();
+		// then
+		assertPosition(f1, a, c);
+		assertPosition(f3, b);
+	}
+
+	@ParameterizedTest
+	@DisplayName("❗ 잘못된 위치")
+	@MethodSource("invalid404Requests")
+	void case10_invalid_NotFound(CommonUpdateFilePositionRequest req) throws Exception {
+		mockMvc.perform(patch(BASE_URL + "/{id}/position", a.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(req))
+			)
+			.andExpect(status().isNotFound());
+	}
+
+	private static Stream<CommonUpdateFilePositionRequest> invalid404Requests() {
+		return Stream.of(
+			new CommonUpdateFilePositionRequest(null, null, 99999L),
+			new CommonUpdateFilePositionRequest(99999L, null, null),
+			new CommonUpdateFilePositionRequest(null, 99999L, null)
+		);
+	}
+
+	@ParameterizedTest
+	@DisplayName("❗ 잘못된 위치")
+	@MethodSource("invalidPositionRequests")
+	void case11_invalid_requests(String bf, String af, String fd) throws Exception {
+		// given
+		Map<String, Story> stories = Map.of(
+			"a", a,
+			"b", b,
+			"c", c,
+			"d", d,
+			"e", e,
+			"f", f
+		);
+		Map<String, StoryFolder> folders = Map.of(
+			"f1", f1,
+			"f2", f2
+		);
+		Story beforeStory = bf == null ? null : stories.get(bf);
+		Story afterStory = af == null ? null : stories.get(af);
+		StoryFolder folderStory = fd == null ? null : folders.get(fd);
+
+		updatePosition(a, beforeStory, afterStory, folderStory)
+			.andExpect(status().isBadRequest());
+	}
+
+	private static Stream<Arguments> invalidPositionRequests() {
+		return Stream.of(
+			Arguments.of(null, null, null),
+			Arguments.of("d", "f", null),
+			Arguments.of("f", "e", null),
+			Arguments.of("d", "b", null),
+			Arguments.of("d", "e", "f1"),
+			Arguments.of("d", null, "f1"),
+			Arguments.of(null, "e", "f1")
+		);
+	}
+
+	@Test
+	@DisplayName("✨ 생성 - 맨 마지막")
+	void createDnd_success() throws Exception {
+		// given
+		CommonAddFileRequest request = new CommonAddFileRequest(
+			"g",
+			f1.getId()
+		);
+
+		// when
+		MvcResult result = mockMvc.perform(post(BASE_URL + "/dnd")
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+			)
+			.andExpect(status().isOk())
+			.andReturn();
+
+		// then
+		String content = result.getResponse().getContentAsString();
+		StoryInfoResponse response = objectMapper.readValue(content, StoryInfoResponse.class);
+
+		assertThat(response.storyId()).isGreaterThan(0L);
+
+		Story g = storyRepository.findById(response.storyId()).orElseThrow();
+		assertThat(g.getName()).isEqualTo("g");
+		assertThat(g.getPosition()).isEqualTo(3L);
+	}
+
+	@Test
+	@DisplayName("✨ 삭제 - 이후 순번 당겨짐")
+	void deleteDnd_success() throws Exception {
+		// when
+		mockMvc.perform(delete(BASE_URL + "/{id}", b.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isNoContent());
+
+		em.flush();
+		em.clear();
+
+		// then
+		assertPosition(f1, a, c);
+	}
+
+	@Test
+	@DisplayName("✨ 복원 - 맨 마지막")
+	void restoreDnd_success() {
+
+	}
+
+	@Test
+	@DisplayName("✨ 복원 - 폴더&파일 맨 마지막")
+	void restoreDnd_withFolder_success() {
+
+	}
+}

--- a/Owing-Api/src/test/java/com/owing/api/story/controller/StoryFolderDnDControllerTest.java
+++ b/Owing-Api/src/test/java/com/owing/api/story/controller/StoryFolderDnDControllerTest.java
@@ -1,0 +1,265 @@
+package com.owing.api.story.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.owing.api.dnd.dto.common.request.CommonAddFolderRequest;
+import com.owing.api.dnd.dto.common.request.CommonUpdateFolderNameRequest;
+import com.owing.api.dnd.dto.common.request.CommonUpdateFolderPositionRequest;
+import com.owing.api.dnd.dto.common.response.CommonFileInfoResponse;
+import com.owing.api.dnd.dto.common.response.CommonFolderInfoResponse;
+import com.owing.api.utils.TestAuthUtils;
+import com.owing.api.utils.TestEnvLoader;
+import com.owing.entity.domains.member.model.Member;
+import com.owing.entity.domains.project.model.Project;
+import com.owing.entity.domains.story.model.Story;
+import com.owing.entity.domains.story.model.StoryFolder;
+import com.owing.entity.domains.story.repository.StoryRepository;
+import com.owing.entity.domains.trashcan.model.FolderType;
+import com.owing.entity.domains.trashcan.repository.TrashCanFolderRepository;
+import com.owing.entity.domains.trashcan.repository.TrashCanRepository;
+
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional("jpaTransactionManager")
+@SpringBootTest
+class StoryFolderDnDControllerTest {
+	private static final String BASE_URL = "/v1/stories/folders";
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private TestAuthUtils testAuthUtils;
+	@Autowired
+	private StoryTest storyTest;
+
+	private Member member;
+	private Project project;
+	private StoryFolder folder;
+	private Story story;
+	@Autowired
+	private TrashCanFolderRepository trashCanFolderRepository;
+	@Autowired
+	private TrashCanRepository trashCanRepository;
+	@Autowired
+	private StoryRepository storyRepository;
+
+	@DynamicPropertySource
+	static void registerProps(DynamicPropertyRegistry registry) {
+		TestEnvLoader.load(registry);
+	}
+
+	@BeforeEach
+	void setUp() {
+		member = testAuthUtils.createMember("test");
+		project = testAuthUtils.createProject(member);
+		folder = storyTest.createStoryFolder(project.getId());
+		story = storyTest.createStory(folder);
+	}
+
+	@Test
+	@DisplayName("✨ Story 폴더 생성 - 성공")
+	void createDnd_success() throws Exception {
+		// given
+		CommonAddFolderRequest request = new CommonAddFolderRequest(
+			"testFolder",
+			project.getId()
+		);
+
+		// when
+		MvcResult result = mockMvc.perform(post(BASE_URL + "/dnd")
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+			)
+			.andExpect(status().isOk())
+			.andReturn();
+
+		// then
+		String content = result.getResponse().getContentAsString();
+		CommonFolderInfoResponse response = objectMapper.readValue(content, CommonFolderInfoResponse.class);
+
+		assertThat(response.getId()).isGreaterThan(0L);
+		assertThat(response.getName()).isEqualTo("testFolder");
+		assertThat(response.getDescription()).isNullOrEmpty();
+	}
+
+	@ParameterizedTest
+	@DisplayName("❗ Story 폴더 생성 - 유효하지 않은 요청값")
+	@MethodSource("invalidDndRequests")
+	void createDnd_invalidRequest(CommonAddFolderRequest invalidRequest) throws Exception {
+		// when // then
+		mockMvc.perform(post(BASE_URL + "/dnd")
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(invalidRequest))
+			)
+			.andExpect(status().isBadRequest());
+	}
+
+	private static Stream<CommonAddFolderRequest> invalidDndRequests() {
+		return Stream.of(
+			new CommonAddFolderRequest(null, 1L),
+			new CommonAddFolderRequest("", 1L),
+			new CommonAddFolderRequest("a".repeat(51), 1L),
+			new CommonAddFolderRequest("valid", null)
+		);
+	}
+
+	@Test
+	@DisplayName("✨ Story 폴더 상세 조회 - 성공")
+	void getDnd_success() throws Exception {
+		// when
+		MvcResult result = mockMvc.perform(get(BASE_URL + "/{id}", folder.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		// then
+		String content = result.getResponse().getContentAsString();
+		CommonFolderInfoResponse response = objectMapper.readValue(content, CommonFolderInfoResponse.class);
+
+		// 폴더 정보 검증
+		assertThat(response.getId()).isEqualTo(folder.getId());
+		assertThat(response.getName()).isEqualTo(folder.getName());
+		assertThat(response.getDescription()).isEqualTo(folder.getDescription());
+		assertThat(response.getProjectId()).isEqualTo(folder.getProjectId());
+
+		// 파일 리스트 검증
+		List<CommonFileInfoResponse> files = response.getFiles();
+		assertThat(files).hasSize(1);
+
+		CommonFileInfoResponse file = files.getFirst();
+		assertThat(file.getId()).isEqualTo(story.getId());
+		assertThat(file.getName()).isEqualTo(story.getName());
+		assertThat(file.getDescription()).isEqualTo(story.getDescription());
+		assertThat(file.getFolderId()).isEqualTo(folder.getId());
+	}
+
+	@Test
+	@DisplayName("❗ Story 폴더 상세 조회 - 존재하지 않는 Id")
+	void getDnd_notFound() throws Exception {
+		// when // then
+		mockMvc.perform(get(BASE_URL + "/{id}", 99999L)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	@DisplayName("✨ Story 폴더 이름 변경 - 성공")
+	void updateDndName_success() throws Exception {
+		// given
+		CommonUpdateFolderNameRequest request = new CommonUpdateFolderNameRequest("updatedName");
+
+		// when // then
+		mockMvc.perform(patch(BASE_URL + "/{id}/title", folder.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNoContent());
+	}
+
+	@ParameterizedTest
+	@DisplayName("❗ Story 폴더 이름 변경 - 유효하지 않은 요청")
+	@MethodSource("invalidFolderNameRequests")
+	void updateDndName_invalidRequest(CommonUpdateFolderNameRequest invalidRequest) throws Exception {
+		// when // then
+		mockMvc.perform(patch(BASE_URL + "/{id}/title", folder.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(invalidRequest)))
+			.andExpect(status().isBadRequest());
+	}
+
+	private static Stream<CommonUpdateFolderNameRequest> invalidFolderNameRequests() {
+		return Stream.of(
+			new CommonUpdateFolderNameRequest(null),
+			new CommonUpdateFolderNameRequest(""),
+			new CommonUpdateFolderNameRequest(" ".repeat(1)),
+			new CommonUpdateFolderNameRequest("a".repeat(51))
+		);
+	}
+
+	@Test
+	@DisplayName("❗Story 폴더 이름 변경 - 존재하지 않는 Id")
+	void updateDndName_notFound() throws Exception {
+		// given
+		CommonUpdateFolderNameRequest request = new CommonUpdateFolderNameRequest("updatedName");
+
+		// when // then
+		mockMvc.perform(patch(BASE_URL + "/{id}/title", 99999L)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	@DisplayName("✨ Story 폴더 위치 이동 - 성공")
+	void updateDndPosition_success() throws Exception {
+		// given
+		Long sf1 = folder.getId();
+		Long sf2 = storyTest.createStoryFolder(project.getId(), "testFolder2", 1L).getId();
+		Long sf3 = storyTest.createStoryFolder(project.getId(), "testFolder3",2L).getId();
+
+		CommonUpdateFolderPositionRequest request = new CommonUpdateFolderPositionRequest(sf1, sf2,
+			project.getId());
+
+		// when // then
+		mockMvc.perform(patch(BASE_URL + "/{id}/position", sf3)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNoContent());
+	}
+
+	@Test
+	@DisplayName("✨ Story 폴더 삭제 - 성공")
+	void deleteDnd_success() throws Exception {
+		// when // then
+		mockMvc.perform(delete(BASE_URL + "/{id}", folder.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isNoContent());
+
+		// trashcan
+		assertThat(trashCanFolderRepository.findByItemIdAndTableName(folder.getId(), FolderType.STORY)).isPresent();
+		assertThat(trashCanRepository.findByItemId(story.getId())).isPresent();
+		assertThat(storyRepository.findById(story.getId())).isEmpty();
+	}
+
+	@Test
+	@DisplayName("❗ Story 폴더 삭제 - 존재하지 않는 Id")
+	void deleteDnd_notFound() throws Exception {
+		// when // then
+		mockMvc.perform(delete(BASE_URL + "/{id}", 99999L)
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isNotFound());
+	}
+
+}

--- a/Owing-Api/src/test/java/com/owing/api/story/controller/StoryFolderDnDShiftTest.java
+++ b/Owing-Api/src/test/java/com/owing/api/story/controller/StoryFolderDnDShiftTest.java
@@ -1,0 +1,273 @@
+package com.owing.api.story.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.owing.api.dnd.dto.common.request.CommonAddFolderRequest;
+import com.owing.api.dnd.dto.common.request.CommonUpdateFolderPositionRequest;
+import com.owing.api.dnd.dto.common.response.CommonFolderInfoResponse;
+import com.owing.api.utils.TestAuthUtils;
+import com.owing.api.utils.TestEnvLoader;
+import com.owing.entity.domains.member.model.Member;
+import com.owing.entity.domains.project.model.Project;
+import com.owing.entity.domains.story.model.Story;
+import com.owing.entity.domains.story.model.StoryFolder;
+import com.owing.entity.domains.story.repository.StoryFolderRepository;
+
+import jakarta.persistence.EntityManager;
+
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional("jpaTransactionManager")
+@SpringBootTest
+class StoryFolderDnDShiftTest {
+	private static final String BASE_URL = "/v1/stories/folders";
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private TestAuthUtils testAuthUtils;
+	@Autowired
+	private StoryTest storyTest;
+
+	private Member member;
+	private Project project;
+	private StoryFolder f1;
+	private Story a;
+	private Story b;
+	private Story c;
+	private StoryFolder f2;
+	private StoryFolder f3;
+	private StoryFolder f4;
+
+	@Autowired
+	private EntityManager em;
+	@Autowired
+	private StoryFolderRepository storyFolderRepository;
+
+	@DynamicPropertySource
+	static void registerProps(DynamicPropertyRegistry registry) {
+		TestEnvLoader.load(registry);
+	}
+
+	@BeforeEach
+	void setUp() {
+		member = testAuthUtils.createMember("test");
+		project = testAuthUtils.createProject(member);
+		f1 = storyTest.createStoryFolder(project.getId(), "aa", 0L);
+		a = storyTest.createStory(f1, "a", 0L);
+		b = storyTest.createStory(f1, "b", 1L);
+		c = storyTest.createStory(f1, "c", 2L);
+		f2 = storyTest.createStoryFolder(project.getId(), "bb", 1L);
+		f3 = storyTest.createStoryFolder(project.getId(), "cc", 2L);
+		f4 = storyTest.createStoryFolder(project.getId(), "dd", 3L);
+	}
+
+	ResultActions updatePosition(StoryFolder folder, StoryFolder before, StoryFolder after, Project project) throws Exception {
+		CommonUpdateFolderPositionRequest req = new CommonUpdateFolderPositionRequest(
+			before == null ? null : before.getId(),
+			after == null ? null : after.getId(),
+			project == null ? null : project.getId()
+		);
+		return mockMvc.perform(patch(BASE_URL + "/{id}/position", folder.getId())
+			.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(req)));
+	}
+
+	void assertPosition(Project project, StoryFolder... expected) {
+		List<StoryFolder> folders = storyFolderRepository.findByParentId(project.getId());
+
+		assertThat(folders).hasSize(expected.length);
+
+		for (int i = 0; i < expected.length; i++) {
+			StoryFolder folder = folders.get(i);
+			System.out.println(folder.getName() + " : " + folder.getPosition());
+			assertThat(folder.getName()).isEqualTo(expected[i].getName());
+			assertThat(folder.getPosition()).isEqualTo(i);
+		}
+	}
+
+	@Test
+	@DisplayName("✨ 동일 폴더 - before only -> before 다음에 위치")
+	void case1_beforeOnly_sameFolder() throws Exception {
+		// when
+		updatePosition(f2, f3, null, project)
+			.andExpect(status().isNoContent());
+		em.flush();
+		em.clear();
+
+		// then
+		assertPosition(project, f1, f3, f2, f4);
+	}
+
+	@Test
+	@DisplayName("✨ 동일 폴더 - after only -> after 이전에 위치")
+	void case2_afterOnly_sameFolder() throws Exception {
+		// when
+		updatePosition(f3, null, f2, project)
+			.andExpect(status().isNoContent());
+		em.flush();
+		em.clear();
+
+		// then
+		assertPosition(project, f1, f3, f2, f4);
+	}
+
+	@Test
+	@DisplayName("✨ 동일 폴더 - before, after -> between 위치")
+	void case3_beforeAfter_sameFolder() throws Exception {
+		// when
+		updatePosition(f3, f1, f2, project)
+			.andExpect(status().isNoContent());
+		em.flush();
+		em.clear();
+		// then
+		assertPosition(project, f1, f3, f2, f4);
+	}
+
+	@ParameterizedTest
+	@DisplayName("❗ 잘못된 위치")
+	@MethodSource("invalid404Requests")
+	void case4_invalid_NotFound(CommonUpdateFolderPositionRequest req) throws Exception {
+		mockMvc.perform(patch(BASE_URL + "/{id}/position", f1.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(req))
+			)
+			.andExpect(status().isNotFound());
+	}
+
+	private static Stream<CommonUpdateFolderPositionRequest> invalid404Requests() {
+		return Stream.of(
+			new CommonUpdateFolderPositionRequest(99999L, null, null),
+			new CommonUpdateFolderPositionRequest(null, 99999L, null)
+		);
+	}
+
+	@ParameterizedTest
+	@DisplayName("❗ 잘못된 위치")
+	@MethodSource("invalidPositionRequests")
+	void case5_invalid_requests(String bf, String af, String fd) throws Exception {
+		// given
+		Project project2 = testAuthUtils.createProject(member);
+		StoryFolder f5 = storyTest.createStoryFolder(project2.getId(), "ee", 0L);
+		StoryFolder f6 = storyTest.createStoryFolder(project2.getId(), "ff", 1L);
+		Map<String, Project> pjs = Map.of(
+			"p1", project,
+			"p2", project2
+		);
+
+		Map<String, StoryFolder> folders = Map.of(
+			"f1", f1,
+			"f2", f2,
+			"f3", f3,
+			"f4", f4,
+			"f5", f5,
+			"f6", f6
+		);
+		StoryFolder beforeStory = bf == null ? null : folders.get(bf);
+		StoryFolder afterStory = af == null ? null : folders.get(af);
+		Project pj = fd == null ? null : pjs.get(fd);
+
+		updatePosition(f4, beforeStory, afterStory, pj)
+			.andExpect(status().isBadRequest());
+	}
+
+	private static Stream<Arguments> invalidPositionRequests() {
+		return Stream.of(
+			Arguments.of(null, null, null),
+			Arguments.of("f1", "f3", null),
+			Arguments.of("f3", "f2", null),
+			Arguments.of("f3", "f1", null),
+			Arguments.of("f5", "f6", "p2"),
+			Arguments.of("f5", null, "p2"),
+			Arguments.of(null, "f6", "p2")
+		);
+	}
+
+	@Test
+	@DisplayName("✨ 생성 - 맨 마지막")
+	void createDnd_success() throws Exception {
+		// given
+		CommonAddFolderRequest request = new CommonAddFolderRequest(
+			"g",
+			project.getId()
+		);
+
+		// when
+		MvcResult result = mockMvc.perform(post(BASE_URL + "/dnd")
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+			)
+			.andExpect(status().isOk())
+			.andReturn();
+
+		// then
+		String content = result.getResponse().getContentAsString();
+		CommonFolderInfoResponse response = objectMapper.readValue(content, CommonFolderInfoResponse.class);
+
+		assertThat(response.getId()).isGreaterThan(0L);
+
+		StoryFolder g = storyFolderRepository.findById(response.getId()).orElseThrow();
+		assertThat(g.getName()).isEqualTo("g");
+		assertThat(g.getPosition()).isEqualTo(4L);
+	}
+
+	@Test
+	@DisplayName("✨ 삭제 - 이후 순번 당겨짐")
+	void deleteDnd_success() throws Exception {
+		// when
+		mockMvc.perform(delete(BASE_URL + "/{id}", f1.getId())
+				.header(AUTHORIZATION, testAuthUtils.getAccessToken(member)))
+			.andExpect(status().isNoContent());
+
+		em.flush();
+		em.clear();
+
+		// then
+		assertPosition(project, f2, f3, f4);
+	}
+
+	@Test
+	@DisplayName("✨ 복원 - 맨 마지막")
+	void restoreDnd_success() {
+
+	}
+
+	@Test
+	@DisplayName("✨ 복원 - 폴더&파일 맨 마지막")
+	void restoreDnd_withFolder_success() {
+
+	}
+}

--- a/Owing-Api/src/test/java/com/owing/api/story/controller/StoryTest.java
+++ b/Owing-Api/src/test/java/com/owing/api/story/controller/StoryTest.java
@@ -1,0 +1,62 @@
+package com.owing.api.story.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.owing.entity.domains.story.model.Story;
+import com.owing.entity.domains.story.model.StoryFolder;
+import com.owing.entity.domains.story.repository.StoryFolderRepository;
+import com.owing.entity.domains.story.repository.StoryRepository;
+
+@Component
+public class StoryTest {
+
+	@Autowired
+	private StoryFolderRepository storyFolderRepository;
+	@Autowired
+	private StoryRepository storyRepository;
+
+	StoryFolder createStoryFolder(Long projectId) {
+		return storyFolderRepository.save(
+			StoryFolder.builder()
+				.name("testFolder")
+				.projectId(projectId)
+				.position(0L)
+				.build()
+		);
+	}
+
+	StoryFolder createStoryFolder(Long projectId, String name, Long position) {
+		return storyFolderRepository.save(
+			StoryFolder.builder()
+				.name(name)
+				.projectId(projectId)
+				.position(position)
+				.build()
+		);
+	}
+
+	Story createStory(StoryFolder folder) {
+		Story story =
+			Story.builder()
+				.name("testFile1")
+				.description("test")
+				.folder(folder)
+				.position(0L)
+				.build();
+		folder.getFiles().add(story);
+		return storyRepository.save(story);
+	}
+
+	Story createStory(StoryFolder folder, String name, Long position) {
+		Story story =
+			Story.builder()
+				.name(name)
+				.description("test")
+				.folder(folder)
+				.position(position)
+				.build();
+		folder.getFiles().add(story);
+		return storyRepository.save(story);
+	}
+}

--- a/Owing-Api/src/test/java/com/owing/api/utils/TestAuthUtils.java
+++ b/Owing-Api/src/test/java/com/owing/api/utils/TestAuthUtils.java
@@ -1,0 +1,57 @@
+package com.owing.api.utils;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.owing.common.util.JwtUtils;
+import com.owing.entity.domains.member.model.Member;
+import com.owing.entity.domains.member.model.OauthProvider;
+import com.owing.entity.domains.member.repository.MemberRepository;
+import com.owing.entity.domains.project.model.Category;
+import com.owing.entity.domains.project.model.Project;
+import com.owing.entity.domains.project.model.ProjectInfo;
+import com.owing.entity.domains.project.repository.ProjectRepository;
+
+@Component
+public class TestAuthUtils {
+	private static final String BEARER_TYPE_SPACE = "Bearer ";
+	@Autowired
+	private	JwtUtils jwtUtils;
+
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private ProjectRepository projectRepository;
+
+	public String getAccessToken(Member member) {
+		return BEARER_TYPE_SPACE + jwtUtils.generateAccessToken(member);
+	}
+
+	public Member createMember(String memberName) {
+		Member member = Member.builder()
+			.email("test")
+			.password("1234")
+			.name(memberName)
+			.nickname("nickname")
+			.phoneNumber("")
+			.provider(OauthProvider.GOOGLE)
+			.build();
+		return memberRepository.save(member);
+	}
+
+	public Project createProject(Member member) {
+		Project project = Project.builder()
+			.projectInfo(
+				ProjectInfo.builder()
+					.title("test")
+					.description("test")
+					.category(Category.OTHER)
+					.coverUrl("test")
+					.build()
+			)
+			.member(member)
+			.build();
+		return projectRepository.save(project);
+	}
+
+}

--- a/Owing-Api/src/test/java/com/owing/api/utils/TestEnvLoader.java
+++ b/Owing-Api/src/test/java/com/owing/api/utils/TestEnvLoader.java
@@ -1,0 +1,17 @@
+package com.owing.api.utils;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+
+import io.github.cdimascio.dotenv.Dotenv;
+
+public class TestEnvLoader {
+	public static void load(DynamicPropertyRegistry registry) {
+		Dotenv dotenv = Dotenv.configure()
+			.directory("../")
+			.filename(".env")
+			.ignoreIfMissing()
+			.load();
+
+		dotenv.entries().forEach(entry -> registry.add(entry.getKey(), entry.getValue()::toString));
+	}
+}

--- a/Owing-Domain/Owing-Entity/src/main/java/com/owing/entity/domains/trashcan/repository/TrashCanRepository.java
+++ b/Owing-Domain/Owing-Entity/src/main/java/com/owing/entity/domains/trashcan/repository/TrashCanRepository.java
@@ -2,6 +2,7 @@ package com.owing.entity.domains.trashcan.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,4 +13,6 @@ public interface TrashCanRepository extends JpaRepository<TrashCan, Long> {
 	List<TrashCan> findAllByTrashCanFolder_Id(Long trashCanFolderId);
 
 	int deleteByCreatedAtBefore(LocalDateTime cutoffDate);
+
+	Optional<TrashCan> findByItemId(Long itemId);
 }


### PR DESCRIPTION
## 📌 연관된 이슈

> #23

## ✌️ Changes

- 기존 테스트코드에서 config 설정, project, member 생성하는 코드 따로 뻈습니다 (계속 쓰기 귀찮아,,
- 테스트 코드가 너무 길어져서 Controller를 Story CRUD - DnD CRUD - AI로 나눠서 작성했습니다
- 추가로 DnD 순서변경 테스트 케이스 빼서 작성
- StoryFolder쪽도 동일하게 적용

기타
- AI 요청보내는 쪽은 아직 안했음
- 순서변경 테케 중에 trashcan 복구 부분은 순서 조정 안되는 부분 오류가 있어서 << 이번에 작업 합니다.